### PR TITLE
refactor: use reduce method to create array of cookies

### DIFF
--- a/csrf/packages/layout/server.js
+++ b/csrf/packages/layout/server.js
@@ -1,68 +1,54 @@
-const express = require('express');
-const Layout = require('@podium/layout');
+const express = require("express");
+const Layout = require("@podium/layout");
 
 const layout = new Layout({
-    name: 'myLayout',
-    pathname: '/',
+  name: "myLayout",
+  pathname: "/",
 });
 
 const podletA = layout.client.register({
-    name: 'form',
-    uri: 'http://localhost:7100/manifest.json',
+  name: "form",
+  uri: "http://localhost:7100/manifest.json",
 });
 
 const podletB = layout.client.register({
-    name: 'json',
-    uri: 'http://localhost:7200/manifest.json',
+  name: "json",
+  uri: "http://localhost:7200/manifest.json",
 });
 
 const podletC = layout.client.register({
-    name: 'no-csrf-button',
-    uri: 'http://localhost:7300/manifest.json',
+  name: "no-csrf-button",
+  uri: "http://localhost:7300/manifest.json",
 });
-
 
 const app = express();
 
 app.use(layout.middleware());
 
 app.get(layout.pathname(), async (req, res, next) => {
-    const incoming = res.locals.podium;
+  const incoming = res.locals.podium;
 
-    const [a, b, c] = await Promise.all([
-        podletA.fetch(incoming),
-        podletB.fetch(incoming),
-        podletC.fetch(incoming),
-    ]);
+  const [a, b, c] = await Promise.all([
+    podletA.fetch(incoming),
+    podletB.fetch(incoming),
+    podletC.fetch(incoming),
+  ]);
 
+  const podlets = [a, b, c];
+  incoming.podlets = podlets;
 
-    incoming.podlets = [a, b, c];
-
-    // Collect all cookies from each podlet into an array of cookies
-    const cookies = [];
-
-    if(Array.isArray(a.headers['set-cookie'])) {
-        a.headers['set-cookie'].forEach((cookie) => {
-            cookies.push(cookie);
-        });
+  // Collect all cookies from each podlet into an array of cookies
+  const cookies = podlets.reduce((acc, curr) => {
+    if (curr.headers && Array.isArray(curr.headers["set-cookie"])) {
+      return [...acc, ...curr.headers["set-cookie"]];
     }
+    return acc;
+  }, []);
 
-    if(Array.isArray(b.headers['set-cookie'])) {
-        b.headers['set-cookie'].forEach((cookie) => {
-            cookies.push(cookie);
-        });
-    }
+  // Set the cookies from the podlets on the response
+  res.setHeader("Set-Cookie", cookies);
 
-    if(Array.isArray(c.headers['set-cookie'])) {
-        c.headers['set-cookie'].forEach((cookie) => {
-            cookies.push(cookie);
-        });
-    }
-
-    // Set the cookies from the podlets on the response
-    res.setHeader('Set-Cookie', cookies);
-    
-    res.status(200).podiumSend(`
+  res.status(200).podiumSend(`
         <div>
             ${a.content}
             <hr>
@@ -74,8 +60,8 @@ app.get(layout.pathname(), async (req, res, next) => {
 });
 
 app.use((err, req, res, next) => {
-    console.error(err.stack);
-    res.status(500).send('Internal error');
+  console.error(err.stack);
+  res.status(500).send("Internal error");
 });
 
-app.listen(7000);
+app.listen(7001);

--- a/csrf/packages/podlet-a/server.js
+++ b/csrf/packages/podlet-a/server.js
@@ -1,25 +1,25 @@
-const express = require('express');
-const Podlet = require('@podium/podlet');
-const csrf = require('csurf');
-const cookieParser = require('cookie-parser');
-const bodyParser = require('body-parser');
+const express = require("express");
+const Podlet = require("@podium/podlet");
+const csrf = require("csurf");
+const cookieParser = require("cookie-parser");
+const bodyParser = require("body-parser");
 
-const development = (process.env.NODE_ENV !== "production");
+const development = process.env.NODE_ENV !== "production";
 
 const app = express();
 
 const podlet = new Podlet({
-    name: 'myPodlet',
-    version: '1.0.0',
-    pathname: '/',
-    development,
+  name: "myPodlet",
+  version: "1.0.0",
+  pathname: "/",
+  development,
 });
 
 // Let document served by layout load assets cross domain
 app.use((req, res, next) => {
-    res.setHeader('Access-Control-Allow-Origin', 'http://localhost:7000');
-    res.setHeader('Access-Control-Allow-Methods', 'GET');
-    next();    
+  res.setHeader("Access-Control-Allow-Origin", "http://localhost:7001");
+  res.setHeader("Access-Control-Allow-Methods", "GET");
+  next();
 });
 
 // The Podium middleware must be set before any body parsing happens
@@ -34,30 +34,32 @@ app.use(cookieParser());
 // Give the CSRF cookie a unique name to avoid name collision
 // when the cookie is re-writen in the layout
 const cookieOptions = {
-    key: 'podlet_a_csrf',
-    secure: !development,
-    httpOnly: true,
-}
+  key: "podlet_a_csrf",
+  secure: !development,
+  httpOnly: true,
+};
 
-app.use(csrf({ 
+app.use(
+  csrf({
     cookie: cookieOptions,
-}));
+  })
+);
 
 app.get(podlet.content(), (req, res) => {
-    // Construct URL under which all proxy routes are located
-    const { mountOrigin, publicPathname } = res.locals.podium.context;
-    const url = new URL(publicPathname, mountOrigin);
+  // Construct URL under which all proxy routes are located
+  const { mountOrigin, publicPathname } = res.locals.podium.context;
+  const url = new URL(publicPathname, mountOrigin);
 
-    // Get CSRF token
-    const token = req.csrfToken();
+  // Get CSRF token
+  const token = req.csrfToken();
 
-    /*
+  /*
         NOTE: The input hidden field for the CSRF token MUST be named "_csrf"
               despite that we are giving the cookie a different name. If not
               the bodyparser will not pick out the token and hand it to
               validation :/
     */
-    const html = `
+  const html = `
         <section>
             <form action="${url.href}/api/form" method="POST" id="a">
                 <input type="hidden" name="_csrf" value="${token}">
@@ -75,26 +77,26 @@ app.get(podlet.content(), (req, res) => {
         </section>
     `;
 
-    res.status(200).podiumSend(html);
+  res.status(200).podiumSend(html);
 });
 
 app.get(podlet.manifest(), (req, res) => {
-    res.status(200).json(podlet);
+  res.status(200).json(podlet);
 });
 
-app.post('/api/form', (req, res) => {
-    res.send('Form successfully posted!');
+app.post("/api/form", (req, res) => {
+  res.send("Form successfully posted!");
 });
 
-podlet.proxy({ target: '/api', name: 'api' });
+podlet.proxy({ target: "/api", name: "api" });
 
-app.use('/static', express.static('public'));
-podlet.js({ value: '/static/form.js', type: 'esm' });
+app.use("/static", express.static("public"));
+podlet.js({ value: "/static/form.js", type: "esm" });
 
 // Serve an error page which will kick in on ex CSRF errors
 app.use((err, req, res, next) => {
-    console.error(err.stack);
-    res.status(403).send('Forbidden');
+  console.error(err.stack);
+  res.status(403).send("Forbidden");
 });
 
 app.listen(7100);

--- a/csrf/packages/podlet-b/server.js
+++ b/csrf/packages/podlet-b/server.js
@@ -1,25 +1,25 @@
-const express = require('express');
-const Podlet = require('@podium/podlet');
-const csrf = require('csurf');
-const cookieParser = require('cookie-parser');
-const bodyParser = require('body-parser');
+const express = require("express");
+const Podlet = require("@podium/podlet");
+const csrf = require("csurf");
+const cookieParser = require("cookie-parser");
+const bodyParser = require("body-parser");
 
-const development = (process.env.NODE_ENV !== "production");
+const development = process.env.NODE_ENV !== "production";
 
 const app = express();
 
 const podlet = new Podlet({
-    name: 'myPodlet',
-    version: '1.0.0',
-    pathname: '/',
-    development,
+  name: "myPodlet",
+  version: "1.0.0",
+  pathname: "/",
+  development,
 });
 
 // Let document served by layout load assets cross domain
 app.use((req, res, next) => {
-    res.setHeader('Access-Control-Allow-Origin', 'http://localhost:7000');
-    res.setHeader('Access-Control-Allow-Methods', 'GET');
-    next();    
+  res.setHeader("Access-Control-Allow-Origin", "http://localhost:7001");
+  res.setHeader("Access-Control-Allow-Methods", "GET");
+  next();
 });
 
 app.use(podlet.middleware());
@@ -31,24 +31,26 @@ app.use(cookieParser());
 // Give the CSRF cookie a unique name to avoid name collision
 // when the cookie is re-writen in the layout
 const cookieOptions = {
-    key: 'podlet_b_csrf',
-    secure: !development,
-    httpOnly: true,
-}
+  key: "podlet_b_csrf",
+  secure: !development,
+  httpOnly: true,
+};
 
-app.use(csrf({ 
+app.use(
+  csrf({
     cookie: cookieOptions,
-}));
+  })
+);
 
 app.get(podlet.content(), (req, res) => {
-    // Construct URL under which all proxy routes are located
-    const { mountOrigin, publicPathname } = res.locals.podium.context;
-    const url = new URL(publicPathname, mountOrigin);
+  // Construct URL under which all proxy routes are located
+  const { mountOrigin, publicPathname } = res.locals.podium.context;
+  const url = new URL(publicPathname, mountOrigin);
 
-    // Get CSRF token
-    const token = req.csrfToken();
+  // Get CSRF token
+  const token = req.csrfToken();
 
-    const html = `
+  const html = `
         <section>
             <button id="json-valid" data-href="${url.href}/api/json" data-token="${token}">Post JSON - Valid CSRF token</button>
         </section>
@@ -58,28 +60,28 @@ app.get(podlet.content(), (req, res) => {
         </section>
     `;
 
-    res.status(200).podiumSend(html);
+  res.status(200).podiumSend(html);
 });
 
 app.get(podlet.manifest(), (req, res) => {
-    res.status(200).json(podlet);
+  res.status(200).json(podlet);
 });
 
-app.post('/api/json', (req, res) => {
-    res.json({
-        'msg': 'Form successfully posted!'
-    });
+app.post("/api/json", (req, res) => {
+  res.json({
+    msg: "Form successfully posted!",
+  });
 });
 
-podlet.proxy({ target: '/api', name: 'api' });
+podlet.proxy({ target: "/api", name: "api" });
 
-app.use('/static', express.static('public'));
-podlet.js({ value: '/static/button.js', type: 'esm' });
+app.use("/static", express.static("public"));
+podlet.js({ value: "/static/button.js", type: "esm" });
 
 // Serve an error page which will kick in on ex CSRF errors
 app.use((err, req, res, next) => {
-    console.error(err.stack);
-    res.status(403).send('Forbidden');
+  console.error(err.stack);
+  res.status(403).send("Forbidden");
 });
 
 app.listen(7200);

--- a/csrf/packages/podlet-c/server.js
+++ b/csrf/packages/podlet-c/server.js
@@ -1,56 +1,56 @@
-const express = require('express');
-const Podlet = require('@podium/podlet');
+const express = require("express");
+const Podlet = require("@podium/podlet");
 
-const development = (process.env.NODE_ENV !== "production");
+const development = process.env.NODE_ENV !== "production";
 
 const app = express();
 
 const podlet = new Podlet({
-    name: 'myPodlet',
-    version: '1.0.0',
-    pathname: '/',
-    development,
+  name: "myPodlet",
+  version: "1.0.0",
+  pathname: "/",
+  development,
 });
 
 // Let document served by layout load assets cross domain
 app.use((req, res, next) => {
-    res.setHeader('Access-Control-Allow-Origin', 'http://localhost:7000');
-    res.setHeader('Access-Control-Allow-Methods', 'GET');
-    next();    
+  res.setHeader("Access-Control-Allow-Origin", "http://localhost:7001");
+  res.setHeader("Access-Control-Allow-Methods", "GET");
+  next();
 });
 
 app.use(podlet.middleware());
 
 app.get(podlet.content(), (req, res) => {
-    // Construct URL under which all proxy routes are located
-    const { mountOrigin, publicPathname } = res.locals.podium.context;
-    const url = new URL(publicPathname, mountOrigin);
+  // Construct URL under which all proxy routes are located
+  const { mountOrigin, publicPathname } = res.locals.podium.context;
+  const url = new URL(publicPathname, mountOrigin);
 
-    // Grab csrf token
-    const token = res.locals.podium.context.csrf
+  // Grab csrf token
+  const token = res.locals.podium.context.csrf;
 
-    const html = `
+  const html = `
         <section>
             <button id="no-csrf-button" data-href="${url.href}/api/json" data-token="${token}">Post JSON - No CSRF</button>
         </section>
     `;
 
-    res.status(200).podiumSend(html);
+  res.status(200).podiumSend(html);
 });
 
 app.get(podlet.manifest(), (req, res) => {
-    res.status(200).json(podlet);
+  res.status(200).json(podlet);
 });
 
-app.post('/api/json', (req, res) => {
-    res.json({
-        'msg': 'Form successfully posted!'
-    });
+app.post("/api/json", (req, res) => {
+  res.json({
+    msg: "Form successfully posted!",
+  });
 });
 
-podlet.proxy({ target: '/api', name: 'api' });
+podlet.proxy({ target: "/api", name: "api" });
 
-app.use('/static', express.static('public'));
-podlet.js({ value: '/static/button.js', type: 'esm' });
+app.use("/static", express.static("public"));
+podlet.js({ value: "/static/button.js", type: "esm" });
 
 app.listen(7300);


### PR DESCRIPTION
Uses the `reduce` method in the layout example to reduce duplicate code when registering podlets to fetch cookies from. The downside of using a `reduce` is readability, but it makes it less error-prone since we only define which podlets to include in one array, rather than copying and pasting a bunch of if/else checks.